### PR TITLE
override

### DIFF
--- a/lib/roo/excelx/sheet_doc.rb
+++ b/lib/roo/excelx/sheet_doc.rb
@@ -89,7 +89,7 @@ module Roo
         #       This works by coincidence because Format[0] is General.
         style = cell_xml['s'].to_i
         # format = styles.style_format(style)
-	format = styles.style_format(10000) # Adding a big number overrides it to General rather than a specific data type
+        format = styles.style_format(10000) # Adding a big number overrides it to General rather than a specific data type
         value_type = cell_value_type(cell_xml['t'], format)
         formula = nil
 

--- a/lib/roo/excelx/sheet_doc.rb
+++ b/lib/roo/excelx/sheet_doc.rb
@@ -88,7 +88,8 @@ module Roo
         # NOTE: This is error prone, to_i will silently turn a nil into a 0.
         #       This works by coincidence because Format[0] is General.
         style = cell_xml['s'].to_i
-        format = styles.style_format(style)
+        # format = styles.style_format(style)
+	format = styles.style_format(10000) # Adding a big number overrides it to General rather than a specific data type
         value_type = cell_value_type(cell_xml['t'], format)
         formula = nil
 


### PR DESCRIPTION
Currently the library erroneously converts a number into date. This change ensures that no magical parsing happens and always the GENERAL format gets picked up which picks the string as it is.
